### PR TITLE
Potential fix for code scanning alert no. 38: Clear-text logging of sensitive information

### DIFF
--- a/agentcore/deployment/deploy_a4a_mcp_handler.py
+++ b/agentcore/deployment/deploy_a4a_mcp_handler.py
@@ -1837,7 +1837,11 @@ class TargetSchemaUpdater:
         if results["gateways_failed"]:
             logger.warning(f"Failed: {len(results['gateways_failed'])} gateway(s)")
             for fail in results["gateways_failed"]:
-                logger.warning(f"  - {fail['gateway']}: {fail['reason']}")
+                raw_gateway = str(fail.get("gateway", "unknown"))
+                masked_gateway = f"***{raw_gateway[-4:]}" if len(raw_gateway) > 4 else "***"
+                raw_reason = str(fail.get("reason", "unknown"))
+                safe_reason = raw_reason if raw_reason in {"target_not_found", "unknown"} else "operation_failed"
+                logger.warning(f"  - {masked_gateway}: {safe_reason}")
 
         results["status"] = "success" if results["gateways_updated"] else "all_failed"
         return results


### PR DESCRIPTION
Potential fix for [https://github.com/aws-solutions-library-samples/guidance-for-advertising-agents-on-aws/security/code-scanning/38](https://github.com/aws-solutions-library-samples/guidance-for-advertising-agents-on-aws/security/code-scanning/38)

To fix this without changing functional behavior, sanitize/redact untrusted values before logging them. The best approach here is to keep the same logging structure and counts, but avoid printing raw `gateway` and `reason` strings. Replace the direct interpolation at line 1840 with a safe summary (masked gateway identifier + normalized reason token). This preserves debugging utility while preventing clear-text leakage of sensitive or attacker-controlled content.

In `agentcore/deployment/deploy_a4a_mcp_handler.py`, update the loop that logs failed gateways (around lines 1838–1841) so it:
1. Reads `fail['gateway']`/`fail['reason']` safely.
2. Masks gateway values (for example: show only last 4 chars).
3. Restricts reason to known safe enum-like values (`target_not_found`, `unknown`) and maps everything else to a generic label.
4. Logs only the sanitized values.

No new dependency is required; built-in Python is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
